### PR TITLE
[Issue Geonode/geonode #4276] Making geonode-avatar python3 compatible

### DIFF
--- a/avatar/forms.py
+++ b/avatar/forms.py
@@ -15,7 +15,7 @@ def avatar_img(avatar, size):
     if not avatar.thumbnail_exists(size):
         avatar.create_thumbnail(size)
     return mark_safe("""<img src="%s" alt="%s" width="%s" height="%s" />""" % 
-        (avatar.avatar_url(size), unicode(avatar), size, size))
+        (avatar.avatar_url(size), str(avatar), size, size))
 
 class UploadAvatarForm(forms.Form):
 

--- a/avatar/models.py
+++ b/avatar/models.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import io
 import hashlib
 
 from django.db import models
@@ -9,17 +10,9 @@ from django.utils.translation import ugettext as _
 from django.utils.encoding import smart_str
 from django.db.models import signals
 
-try:
-    from cStringIO import StringIO
-    dir(StringIO) # Placate PyFlakes
-except ImportError:
-    from StringIO import StringIO
 
-try:
-    from PIL import Image
-    dir(Image) # Placate PyFlakes
-except ImportError:
-    import Image
+from io import StringIO
+from PIL import Image
 
 from avatar.util import invalidate_cache
 from avatar.settings import (AVATAR_STORAGE_DIR, AVATAR_RESIZE_METHOD,
@@ -97,8 +90,7 @@ class Avatar(models.Model):
         # invalidate the cache of the thumbnail with the given size first
         invalidate_cache(self.user, size)
         try:
-            orig = self.avatar.storage.open(self.avatar.name, 'rb').read()
-            image = Image.open(StringIO(orig))
+            image = Image.open(self.avatar.name)
         except IOError:
             return # What should we do here?  Render a "sorry, didn't work" img?
         quality = quality or AVATAR_THUMB_QUALITY

--- a/avatar/settings.py
+++ b/avatar/settings.py
@@ -1,10 +1,6 @@
 from django.conf import settings
 
-try:
-    from PIL import Image
-    dir(Image) # Placate PyFlakes
-except ImportError:
-    import Image
+from PIL import Image
 
 AVATAR_DEFAULT_SIZE = getattr(settings, 'AVATAR_DEFAULT_SIZE', 80)
 AUTO_GENERATE_AVATAR_SIZES = getattr(settings, 'AUTO_GENERATE_AVATAR_SIZES', (AVATAR_DEFAULT_SIZE,))

--- a/avatar/templates/avatar/add.html
+++ b/avatar/templates/avatar/add.html
@@ -7,8 +7,8 @@
     {% if not avatars %}
         <p>{% trans "You haven't uploaded an avatar yet. Please upload one now." %}</p>
     {% endif %}
-    <form enctype="multipart/form-data" method="POST" action="{% url avatar_add %}">
+    <form enctype="multipart/form-data" method="POST" action="{% url 'avatar_add' %}">
         {{ upload_avatar_form.as_p }}
-        <p>{% csrf_token %}<input type="submit" value="{% trans "Upload New Image" %}" /></p>
+        <p>{% csrf_token %}<input type="submit" value="{% trans 'Upload New Image' %}" /></p>
     </form>
 {% endblock %}

--- a/avatar/templatetags/avatar_tags.py
+++ b/avatar/templatetags/avatar_tags.py
@@ -4,7 +4,7 @@ import hashlib
 
 from django import template
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from django.contrib.auth import get_user_model
 

--- a/avatar/tests.py
+++ b/avatar/tests.py
@@ -1,7 +1,7 @@
 import os.path
 
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 
 from django.contrib.auth import get_user_model

--- a/avatar/urls.py
+++ b/avatar/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.conf.urls import include, url
 
 from . import views
 
@@ -7,4 +7,5 @@ urlpatterns = [  # 'avatar.views',
     url('^change/$', views.change, name='avatar_change'),
     url('^delete/$', views.delete, name='avatar_delete'),
     url('^render_primary/(?P<user>[\+\w]+)/(?P<size>[\d]+)/$', views.render_primary, name='avatar_render_primary'),
+    url('^comments/', include('django_comments.urls')),
 ]

--- a/avatar/views.py
+++ b/avatar/views.py
@@ -128,10 +128,10 @@ def delete(request, extra_context=None, next_override=None, *args, **kwargs):
     if request.method == 'POST':
         if delete_avatar_form.is_valid():
             ids = delete_avatar_form.cleaned_data['choices']
-            if unicode(avatar.id) in ids and avatars.count() > len(ids):
+            if str(avatar.id) in ids and avatars.count() > len(ids):
                 # Find the next best avatar, and set it as the new primary
                 for a in avatars:
-                    if unicode(a.id) not in ids:
+                    if str(a.id) not in ids:
                         a.primary = True
                         a.save()
                         avatar_updated.send(sender=Avatar, user=request.user, avatar=avatar)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Pillow
+django-contrib-comments==1.9.1
+Django>=1.11,<2.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,20 @@
+
+
+try:  # for pip >= 10
+    from pip._internal.req import parse_requirements
+    from pip._internal.download import PipSession
+except ImportError:  # for pip <= 9.0.3
+    from pip.req import parse_requirements
+    from pip.download import PipSession
+
 from setuptools import setup, find_packages
 
 version = '2.1.8'
+
+# Parse requirements.txt to get the list of dependencies
+inst_req = parse_requirements('requirements.txt',
+                              session=PipSession())
+REQUIREMENTS = [str(r.req) for r in inst_req]
 
 LONG_DESCRIPTION = """
 Using geonode-avatar
@@ -154,6 +168,7 @@ setup(
         "Framework :: Django",
         "Environment :: Web Environment",
     ],
+    python_requires='>=3',
     keywords='avatar,django',
     author='Ariel Nunez',
     author_email='ingenieroariel@gmail.com',
@@ -169,5 +184,6 @@ setup(
         ],
     },
     include_package_data=True,
+    install_requires=REQUIREMENTS,
     zip_safe=False,
 )

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -4,13 +4,16 @@ import os
 import sys
 import tempfile
 
+import django
+from django.conf import settings
+from django.test.utils import get_runner
+
 ROOT = os.path.abspath(os.path.dirname(__file__))
 APP_ROOT = os.path.join(ROOT, '..')
 sys.path.append(APP_ROOT)
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 
-from django.conf import settings
 
 # We do this here because settings.py has a tendency to be imported more than
 # once, in certain situations, and we only want one temporary test folder.
@@ -18,10 +21,12 @@ MEDIA_ROOT = os.path.join(tempfile.gettempdir(), 'avatars')
 if not os.path.exists(MEDIA_ROOT):
     os.makedirs(os.path.join(MEDIA_ROOT, 'test'))
 settings.MEDIA_ROOT = MEDIA_ROOT
- 
-from django.test.simple import run_tests
+
 
 if __name__ == "__main__":
-    failures = run_tests(['avatar'], verbosity=1)
+    django.setup()
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner()
+    failures = test_runner.run_tests(['avatar'], verbosity=1)
     if failures:
         sys.exit(failures)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,11 +1,15 @@
-from django.conf.urls import patterns, include, handler500, handler404
- 
+import os
+
 DEFAULT_CHARSET = 'utf-8'
- 
-DATABASE_ENGINE = 'sqlite3'
-DATABASE_NAME = ':memory:'
- 
-ROOT_URLCONF = 'settings'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+
+ROOT_URLCONF = 'avatar.urls'
 
 STATIC_URL = '/site_media/static/'
 
@@ -16,21 +20,28 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sites',
-    'django.contrib.comments',
+    'django_comments',
     'avatar',
 )
- 
-TEMPLATE_LOADERS = (
-    'django.template.loaders.app_directories.load_template_source',
-)
- 
+
+MIDDLEWARE = [
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+]
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath('avatar')))
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
+        'APP_DIRS': True,
+    },
+]
+
+SECRET_KEY = "nothing important"
+
 AVATAR_ALLOWED_FILE_EXTS = ('.jpg', '.png')
 AVATAR_MAX_SIZE = 1024 * 1024
 AVATAR_MAX_AVATARS_PER_USER = 20
- 
-urlpatterns = patterns('',
-    (r'^avatar/', include('avatar.urls')),
-)
-
-def __exported_functionality__():
-    return (handler500, handler404)


### PR DESCRIPTION
This PR relates to https://github.com/GeoNode/geonode/issues/4276 for upgrading to python3.

Changes made include:
- Added a requirement.text file for the dependencies
- Changed imports that are not compatible with python3
- Changed deprecated python 2 methods to their python 3 equivalents

Tests run successfully after the changes by running `python tests/runtests.py` assuming it is in a python3 environment