### PR TITLE
Update pillow version as in geonode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Pillow==7.0.0
+Pillow==7.1.2
 django-contrib-comments>=1.9.1
 Django>=2


### PR DESCRIPTION
<img width="921" alt="error" src="https://user-images.githubusercontent.com/16238300/81322680-f4dda900-90b1-11ea-9c40-70eca1857d62.png">
Please Check this error. This Error because we use pillow=7.1.2 in geonode but in geonode-avatar use pillow=7.0.0 